### PR TITLE
Fixed square brackets being treated as an array index when not following a variable

### DIFF
--- a/syntax/fish.vim
+++ b/syntax/fish.vim
@@ -64,7 +64,7 @@ syntax match fishDoubleQuoteEscape /\\[\\"$\n]/ contained
 syntax cluster fishStringEscape contains=fishSingleQuoteEscape,fishDoubleQuoteEscape
 
 syntax region fishString start=/'/ skip=/\v(\\{2})|(\\)'/ end=/'/ contains=fishSingleQuoteEscape
-syntax region fishString start=/"/ skip=/\v(\\{2})|(\\)"/ end=/"/ contains=fishDoubleQuoteEscape,fishDeref,fishDerefExtension
+syntax region fishString start=/"/ skip=/\v(\\{2})|(\\)"/ end=/"/ contains=fishDoubleQuoteEscape,fishDeref
 syntax match fishCharacter /\v\\[0abefnrtv *?~%#(){}\[\]<>&;"']|\\[xX][0-9a-f]{1,2}|\\o[0-7]{1,2}|\\u[0-9a-f]{1,4}|\\U[0-9a-f]{1,8}|\\c[a-z]/
 syntax match fishCharacter /\v\\e[a-zA-Z0-9]/
 


### PR DESCRIPTION
Previously highlighting would treat any starting square bracket `[` in a string as an index operator whether or not it followed a variable, ie: 
![old](https://user-images.githubusercontent.com/42655736/219529929-e4db03b6-5ae5-4ad4-99a7-17565a33d6a8.png)

With this change only square brackets which follow a variable are highlighter within strings, ie:
![new](https://user-images.githubusercontent.com/42655736/219530285-129129ad-0316-4887-bb1d-066257aab4c7.png)

